### PR TITLE
Flush log output immediately instead of buffering

### DIFF
--- a/ikp3db.py
+++ b/ikp3db.py
@@ -174,7 +174,7 @@ class IKPdbLogger(object, metaclass=MetaIKPdbLogger):
                 string = message % args
             except:
                 string = message+"".join([str(e) for e in args])
-            print(IKPdbLogger.TEMPLATES[level//10] % (domain, ts, string,), file=sys.stderr) 
+            print(IKPdbLogger.TEMPLATES[level//10] % (domain, ts, string,), file=sys.stderr, flush=True) 
 
 _logger = IKPdbLogger
 


### PR DESCRIPTION
In ikpdb logging output is immediately pushed to stderr (https://github.com/audaxis/ikpdb/blob/master/ikpdb.py#L180), while in ikp3db it is currently buffered until the process is terminated. This changes makes the output flush immediately to be consistent with ikpdb.