### PR TITLE
FIX: avoid condition inequality in cloud9 plugin

### DIFF
--- a/ikp3db.py
+++ b/ikp3db.py
@@ -1436,7 +1436,7 @@ class IKPdb(object):
                 # canonic() method.
                 file_name = args['file_name']
                 line_number = args['line_number']
-                condition = args.get('condition', '')
+                condition = args.get('condition', None)
                 enabled = args.get('enabled', True)
                 _logger.b_debug("setBreakpoint(file_name=%s, line_number=%s,"
                                 " condition=%s, enabled=%s) with CWD=%s",


### PR DESCRIPTION
The condition at https://github.com/c9/core/blob/15911b3ed65e69efd27d19683a2ac90c69ca4242/plugins/c9.ide.run.debug.ikpdb/ikpdb.js#L394 evaluates to `false` if the value of `condition` is `''`.