### PR TITLE
Support utf-8 characters in python source file

### DIFF
--- a/ikp3db.py
+++ b/ikp3db.py
@@ -1397,7 +1397,7 @@ class IKPdb(object):
 
         self.mainpyfile = self.canonic(filename)
         #statement = 'execfile(%r)\n' % filename
-        statement = "exec(compile(open('%s').read(), '%s', 'exec'))" % (filename, filename,)
+        statement = "exec(compile(open('%s', encoding='utf-8').read(), '%s', 'exec'))" % (filename, filename,)
         
         globals = __main__.__dict__
         locals = globals


### PR DESCRIPTION
test3.py:
```
#!/usr/bin/env python3
# -*- coding: utf-8 -*-
# 中文 --------------utf-8 characters-----------------
while 1:
	a=[]  
	s = input()
	
	if s != "":
		for x in s.split():  
		    a.append(int(x))  
		   
		print(sum(a))
	else:
		break
```
If not set encoding to utf-8, there will be some errors as follows:
```
Traceback (most recent call last):
  File "//usr/local/lib/python3.6/dist-packages/ikp3db.py", line 1864, in main
    ikpdb._runscript(mainpyfile)
  File "//usr/local/lib/python3.6/dist-packages/ikp3db.py", line 1414, in _runscript
    exec(statement, globals, locals)
  File "<string>", line 1, in <module>
  File "//usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 49: ordinal not in range(128)
```