### PR TITLE
IMP: Add support for log file, use termcolor

### DIFF
--- a/ikp3db.py
+++ b/ikp3db.py
@@ -25,7 +25,6 @@ import io
 import ctypes
 import cgi
 import enum
-import termcolor
 
 import iksettrace3
 
@@ -80,6 +79,13 @@ class IKPdbLogger(object, metaclass=MetaIKPdbLogger):
     - allow IKP3db debugging...
     """
 
+    class COLORS(enum.Enum):
+        DEFAULT = 0
+        RED = 31
+        GREEN = 32
+        YELLOW = 33
+        BLUE = 34
+
     class LEVELS(enum.Enum):
         NOLOG = 0
         DEBUG = 10
@@ -89,7 +95,7 @@ class IKPdbLogger(object, metaclass=MetaIKPdbLogger):
         CRITICAL = 50
 
     # Level to color mapping
-    COLORS = ["blue", "blue", "green", "yellow", "red", "red"]
+    LEVEL_COLORS = [COLORS.BLUE, COLORS.BLUE, COLORS.GREEN, COLORS.YELLOW, COLORS.RED, COLORS.RED]
 
     enabled = False
 
@@ -98,10 +104,10 @@ class IKPdbLogger(object, metaclass=MetaIKPdbLogger):
 
     @classmethod
     def templates(cls, level):
-        def _colored(*args, **kwargs):
-            return args[0] if IKPdbLogger._nocolor else termcolor.colored(*args, **kwargs)
+        def _colored(text, color=IKPdbLogger.COLORS.DEFAULT, bold=False):
+            return text if IKPdbLogger._nocolor else "\033[%d%sm%s\033[0m" % (color.value, ";1" if bold else "", text)
 
-        return _colored("IKP3db - %s", attrs=["bold"]) + " %s - " + _colored(IKPdbLogger.LEVELS(level).name, IKPdbLogger.COLORS[level.value // 10]) + " - %s"
+        return _colored("IKP3db - %s", bold=True) + " %s - " + _colored(IKPdbLogger.LEVELS(level).name, IKPdbLogger.LEVEL_COLORS[level.value // 10]) + " - %s"
 
     @classmethod
     def setup(cls, ikpdb_log_arg, ikpdb_log_nocolor_arg=False, ikpdb_log_file_arg=None):

--- a/ikp3db.py
+++ b/ikp3db.py
@@ -63,7 +63,10 @@ class IKPdbLoggerError(Exception):
 class MetaIKPdbLogger(type):
     def __getattr__(cls, name):
         domain, level_name = name.split('_')
-        level = IKPdbLogger.LEVELS[level_name.upper()]
+        try:
+            level = IKPdbLogger.LEVELS[level_name.upper()]
+        except KeyError:
+            level = None
         if domain not in IKPdbLogger.DOMAINS or not level:
             raise IKPdbLoggerError("'%s' is not valid logging domain and level combination !" % name)
             

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
     author='Cyril MORISSE, Audaxis',
     author_email='cmorisse@boxes3.net',
     description="A hackable CPython 3.6+ remote debugger designed for the Web and online IDE integration. Fork of IKPdb.",
-    install_requires=["termcolor"],
     long_description = long_description,
     keywords = "debugger debug remote tcp",
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 from setuptools import setup, find_packages, Extension
 
 name = 'ikp3db'
-version = '1.4'
+version = '1.4.1'
 
 if sys.version_info[:2] < (3,6):
     sys.exit('Sorry, IKPdb only supports Python 3.6 and above.')
@@ -31,6 +31,7 @@ setup(
     author='Cyril MORISSE, Audaxis',
     author_email='cmorisse@boxes3.net',
     description="A hackable CPython 3.6+ remote debugger designed for the Web and online IDE integration. Fork of IKPdb.",
+    install_requires=["termcolor"],
     long_description = long_description,
     keywords = "debugger debug remote tcp",
     include_package_data=True,


### PR DESCRIPTION
Most of our users are students who are new to computer science and programming so we constantly try to simplify things for them to avoid confusion and make their experience better. This PR just adds support for optionally redirecting ikp3db logs to a log file (through the `--ikpdb-log-file` command-line option if present), disabling ANSI coloring in this case. I've also switched to `termcolor` for coloring output which felt nicer than hard-coding ANSI escape sequences.