### PR TITLE
Support for python3.10

### DIFF
--- a/ikp3db.py
+++ b/ikp3db.py
@@ -30,7 +30,7 @@ import iksettrace3
 
 # For now ikpdb is a singleton
 ikpdb = None 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 ##
 # Logging System

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 from setuptools import setup, find_packages, Extension
 
 name = 'ikp3db'
-version = '1.4.1'
+version = '1.4.2'
 
 if sys.version_info[:2] < (3,6):
     sys.exit('Sorry, IKPdb only supports Python 3.6 and above.')


### PR DESCRIPTION
Hi Cyril,

First off, thank you for creating the package, after many years it's still being used in the Cloud9 IDE as a python debugger.

As mentioned in  #13, the package fails to install on Python3.10 due to removal of `PyThreadState.use_tracing` (https://github.com/python/cpython/issues/87926).

This pull request adds support for Python3.10 by conditionally setting `PyThreadState.use_tracing` or `PyThreadState.cframe.use_tracing` depending on the Python version.

I tested it on Python3.6 and 3.10.

I also bumped the version to 1.4.2, I don't know if that's acceptable or you'd want to set it to 1.5.0 or something.

Any chance this PR can be merged and released to PyPI?

Regards,
Sergey

