### PR TITLE
Crdsteixeira patch python3.11

### DIFF
--- a/ikp3db.py
+++ b/ikp3db.py
@@ -30,7 +30,7 @@ import iksettrace3
 
 # For now ikpdb is a singleton
 ikpdb = None 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 
 ##
 # Logging System

--- a/iksettrace3.c
+++ b/iksettrace3.c
@@ -46,7 +46,7 @@ get_frame_trace(PyFrameObject *frame)
     PyObject *trace_func = NULL;
     PyObject *locals_dict = PyFrame_GetLocals(frame);
     if (locals_dict && PyDict_Check(locals_dict)) {
-        trace_func = PyDict_GetItemString(locals_dict, "_tracefunc");
+        trace_func = PyDict_GetItemString(locals_dict, "__tracefunc__");
         Py_XINCREF(trace_func);
     }
     return trace_func;
@@ -58,9 +58,9 @@ set_frame_trace(PyFrameObject *frame, PyObject *trace_func)
     PyObject *locals_dict = PyFrame_GetLocals(frame);
     if (locals_dict && PyDict_Check(locals_dict)) {
         if (trace_func) {
-            PyDict_SetItemString(locals_dict, "_tracefunc", trace_func);
+            PyDict_SetItemString(locals_dict, "__tracefunc__", trace_func);
         } else {
-            PyDict_DelItemString(locals_dict, "_tracefunc");
+            PyDict_DelItemString(locals_dict, "__tracefunc__");
         }
     }
 }
@@ -96,13 +96,12 @@ trace_trampoline(PyObject *self, PyFrameObject *frame,
 {
     PyObject *callback;
     PyObject *result;
-    
+
     if (what == PyTrace_CALL)
         callback = self;
-    else {
+    else
         callback = get_frame_trace(frame);
-    }
-    
+
     if (callback == NULL)
         return 0;
 
@@ -120,7 +119,7 @@ trace_trampoline(PyObject *self, PyFrameObject *frame,
         Py_DECREF(result);
         Py_CLEAR(callback);
     }
-    
+
     return 0;
 }
 
@@ -152,7 +151,7 @@ IK_SetTrace(Py_tracefunc func, PyObject *arg)
     PyInterpreterState *interp = PyInterpreterState_Head();
     PyThreadState *loopThreadState = PyInterpreterState_ThreadHead(interp);
     while(loopThreadState) {
-         if((unsigned long)loopThreadState->thread_id != (unsigned long)debuggerThreadIdent) {
+        if ((unsigned long)loopThreadState->thread_id != (unsigned long)debuggerThreadIdent) {
             PyObject *temp = loopThreadState->c_traceobj;
             Py_XINCREF(arg);
             loopThreadState->c_tracefunc = NULL;

--- a/iksettrace3.c
+++ b/iksettrace3.c
@@ -63,6 +63,8 @@ set_frame_trace(PyFrameObject *frame, PyObject *trace_func)
             PyDict_DelItemString(locals_dict, "__tracefunc__");
         }
     }
+
+    Py_XDECREF(trace_func);
 }
 
 static PyObject *
@@ -106,18 +108,11 @@ trace_trampoline(PyObject *self, PyFrameObject *frame,
         return 0;
 
     result = call_trampoline(callback, frame, what, arg);
+    set_frame_trace(frame, result);
+
     if (result == NULL) {
         PyEval_SetTrace(NULL, NULL);
-        Py_CLEAR(callback);
         return -1;
-    }
-
-    if (result != Py_None) {
-        set_frame_trace(frame, result);
-        Py_DECREF(result);
-    } else {
-        Py_DECREF(result);
-        Py_CLEAR(callback);
     }
 
     return 0;


### PR DESCRIPTION
Closes #17 

Added get_frame_trace and set_frame_trace which use local attributes to store trace pointer since Python C-API no longer exposes these functionalities.

Update trace_trampoline to use the new functions.

While at it, fixed missing unsigned long casting.

Change the tracefunc to use a dunder method so that modules do not see the new pointer as a variable.

Also, fix some extra spacings from previous commit.